### PR TITLE
Correct loading of `proc_unix.lua` to `proc_posix.lua``

### DIFF
--- a/proc.lua
+++ b/proc.lua
@@ -5,7 +5,7 @@
 if not ... then require'proc_test'; return end
 
 local ffi = require'ffi'
-local current_platform = ffi.os == 'Windows' and 'win' or 'unix'
+local current_platform = ffi.os == 'Windows' and 'win' or 'posix'
 local M = require('proc_'..current_platform)
 
 local function extend(dt, t)


### PR DESCRIPTION
When attempting to use `proc.lua` on a non-Windows platform, it would attempt to load a non-existent `proc_unix.lua`. This corrects it to load `proc_posix.lua`.